### PR TITLE
Don't set readline editing-mode vim by default

### DIFF
--- a/inputrc-sample
+++ b/inputrc-sample
@@ -1,3 +1,6 @@
+# A sample .inputrc file to change all of your command-line editing to VIM-style.
+# Not for everyone. Copy to ~/.inputrc to try it.
+
 set editing-mode vi
 
 set bind-tty-special-chars off


### PR DESCRIPTION
I propose not having a .inputrc in this repo by default. Using this repo in conjuntion with loop-dots causes this .inputrc to be loaded automatically, changing all readline to vi-mode, which is confusing if you weren't expecting it, and hard to track down.
